### PR TITLE
resolvendo treta conhecida do IntellJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ target/*
 .classpath
 .project
 .pydevproject
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-jasper</artifactId>
-			<scope>provided</scope>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/src/main/java/com/github/sadufcg/Application.java
+++ b/src/main/java/com/github/sadufcg/Application.java
@@ -4,8 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@EnableAutoConfiguration
-@SpringBootApplication 
+@SpringBootApplication
 public class Application {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Resolvendo a Issue #5. Era um problema comum que ocorre ao compilar um projeto eclipse em um maven. Bastou mudar o scope do tomcat de `provided` para `compile`. 